### PR TITLE
Improve homepage performance

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Disallow: /admin
 Allow: /
 
-Sitemap: https://yourdomain.com/sitemap.xml
+Sitemap: https://kiro.bg/sitemap.xml

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,33 @@
 import Home from '../components/Home/Home';
 import {Suspense} from 'react';
 import {generalMetadata} from './utulities/generalMetadata';
+import {getPaginatedPostsData} from './lib/api';
 
 export const generateMetadata = async () => {
   return generalMetadata();
 };
 
-export default function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: {page?: string; searchTerm?: string};
+}) {
+  const page = parseInt(searchParams?.page || '1', 10);
+  const searchTerm = searchParams?.searchTerm || '';
+  const POSTS_PER_PAGE = 10;
+
+  const {posts, totalPages} = await getPaginatedPostsData(
+    page,
+    POSTS_PER_PAGE,
+    searchTerm
+  );
+
   return (
     <Suspense fallback={<div>Зареждам...</div>}>
-      <Home />
+      <Home
+        initialPosts={posts}
+        initialTotalPages={totalPages}
+      />
     </Suspense>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,12 @@ export const generateMetadata = async () => {
 export default async function Page({
   searchParams,
 }: {
-  searchParams?: {page?: string; searchTerm?: string};
+  searchParams?: Promise<{page?: string; searchTerm?: string}>;
 }) {
-  const page = parseInt(searchParams?.page || '1', 10);
-  const searchTerm = searchParams?.searchTerm || '';
+  const resolvedSearchParams = await searchParams;
+
+  const page = parseInt(resolvedSearchParams?.page || '1', 10);
+  const searchTerm = resolvedSearchParams?.searchTerm || '';
   const POSTS_PER_PAGE = 10;
 
   const {posts, totalPages} = await getPaginatedPostsData(
@@ -24,10 +26,7 @@ export default async function Page({
 
   return (
     <Suspense fallback={<div>Зареждам...</div>}>
-      <Home
-        initialPosts={posts}
-        initialTotalPages={totalPages}
-      />
+      <Home initialPosts={posts} initialTotalPages={totalPages} />
     </Suspense>
   );
 }

--- a/src/app/utulities/fetchPosts.ts
+++ b/src/app/utulities/fetchPosts.ts
@@ -1,5 +1,3 @@
-
-
 export async function fetchPosts(page: number, searchTerm: string = '') {
   try {
     const baseUrl = process.env.NEXT_PUBLIC_SITE_URL

--- a/src/app/utulities/fetchPosts.ts
+++ b/src/app/utulities/fetchPosts.ts
@@ -1,4 +1,4 @@
-'use server';
+
 
 export async function fetchPosts(page: number, searchTerm: string = '') {
   try {
@@ -8,9 +8,7 @@ export async function fetchPosts(page: number, searchTerm: string = '') {
     const url = `${baseUrl}/api/posts?page=${page}&searchTerm=${encodeURIComponent(searchTerm)}`;
 
     const response = await fetch(url, {
-      // next: {revalidate: 3600}, // Cache for 1 hour
-      cache: 'no-store',
-      next: {revalidate: 0},
+      next: {revalidate: 3600},
     });
 
     if (!response.ok) {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import {useSearch} from '../Search/SearchProvider/SearchProvider';
 import SearchPosts from '../Search/Search';
 import {Suspense} from 'react';
-import router from 'next/router';
 
 const Header = () => {
   const {colorMode} = useColorMode();
@@ -34,7 +33,6 @@ const Header = () => {
             href="/"
             onClick={() => {
               setPosts([]);
-              router.push('/');
             }}
           >
             <Heading size="lg" color={mainTextColor}>

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -80,7 +80,13 @@ export default function Home({
     };
 
     fetchData();
-  }, [currentPage, initialSearchTerm, initialPosts, initialTotalPages, setPosts]);
+  }, [
+    currentPage,
+    initialSearchTerm,
+    initialPosts,
+    initialTotalPages,
+    setPosts,
+  ]);
 
   const PaginationComponent = () => {
     return posts?.length ? (


### PR DESCRIPTION
## Summary
- hydrate robots.txt with live domain
- fetch posts server-side
- keep client navigation simple
- enable caching when fetching posts

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: Cannot find package 'gray-matter')*

------
https://chatgpt.com/codex/tasks/task_e_6870d9ef05208332973b4a3a783d0510